### PR TITLE
go/Makefile: Fix for go 1.8

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -7,12 +7,8 @@ VERSION=$(shell git describe --tags --always --dirty)
 
 GO_VERSION=$(strip $(shell go version | sed 's/.*go\([0-9]*\.[0-9]*\).*/\1/'))
 
-# Older versions of Go use the "-X foo bar" syntax.  Newer versions either warn
-# or error on that syntax, and use "-X foo=bar" instead.
-LINK_SEPERATOR=$(if $(filter 1.5, $(word 1, $(sort 1.5 $(GO_VERSION)))),=, )
-
 $(GOBINS): src/gobwa/bwa/libbwa.a
-	go install -ldflags "-X inference.__VERSION__$(LINK_SEPERATOR)'$(VERSION)'" $@
+	go install -ldflags "-X inference.__VERSION__='$(VERSION)'" $@
 
 src/gobwa/bwa/libbwa.a:
 	make -C src/gobwa/bwa libbwa.a


### PR DESCRIPTION
Fix the error:
```
link: -X flag requires argument of the form importpath.name=value
```